### PR TITLE
2nd draft of adding lockfile to singlerun

### DIFF
--- a/epub_to_coresourceSend.rb
+++ b/epub_to_coresourceSend.rb
@@ -8,8 +8,8 @@ require_relative '../bookmaker/core/metadata.rb'
 local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
 outputdirs_json = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_connectors", "bookmakerbot_outputdirs.json")
-epubregexp = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "*.epub")
-epub_errfile = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "EPUBCHECK_ERROR.txt")
+epubregexp = File.join(Metadata.final_dir, "*.epub")
+epub_errfile = File.join(Metadata.final_dir, "EPUBCHECK_ERROR.txt")
 testing_value_file = File.join(Bkmkr::Paths.resource_dir, "staging.txt")
 
 # ---------------------- METHODS


### PR DESCRIPTION
1 of a set of 5 PR's to handle concurrent bookmaker runs, both with the tmpdir & the done_dir.
Straightforward unless a 'locked' done dir for the exact same ISBN exists, then it retries every minute for 15 minutes, then spawns a new done_dir with an error.txt in the root.
Repos affected:
bookmaker (macmillanpublishers/bookmaker#216)
bookmaker_addons (macmillanpublishers/bookmaker_addons#203)
bookmaker_connectors
pitstop_watch (https://github.com/macmillanpublishers/pitstop_watch/pull/6)
covermaker